### PR TITLE
Add workout programs REST API

### DIFF
--- a/drizzle/0007_volatile_richard_fisk.sql
+++ b/drizzle/0007_volatile_richard_fisk.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "program_weeks" ALTER COLUMN "week_number" SET DEFAULT 1;--> statement-breakpoint
+ALTER TABLE "workout_programs" ALTER COLUMN "duration_weeks" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "program_weeks" ADD COLUMN "day_label" varchar(50);--> statement-breakpoint
+ALTER TABLE "workout_programs" ADD COLUMN "days_per_week" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "workout_programs" ADD COLUMN "is_active" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "workout_programs" ADD COLUMN "current_day_index" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "workout_programs" ADD COLUMN "times_completed" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "program_weeks_program_id_idx" ON "program_weeks" USING btree ("program_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workout_programs_user_active_idx" ON "workout_programs" USING btree ("user_id","is_active");

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,3241 @@
+{
+  "id": "2c540473-0da0-447d-9e1d-06a9f58d63bb",
+  "prevId": "48f54fdc-9c2d-43f1-9b34-1457786ffc62",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.competition_participants": {
+      "name": "competition_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_score": {
+          "name": "current_score",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_participants_comp_user_idx": {
+          "name": "competition_participants_comp_user_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_participants_competition_idx": {
+          "name": "competition_participants_competition_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_participants_competition_id_competitions_id_fk": {
+          "name": "competition_participants_competition_id_competitions_id_fk",
+          "tableFrom": "competition_participants",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_participants_user_id_users_id_fk": {
+          "name": "competition_participants_user_id_users_id_fk",
+          "tableFrom": "competition_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "metric": {
+          "name": "metric",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_exercise_id": {
+          "name": "target_exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "entry_code": {
+          "name": "entry_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitions_creator_id_idx": {
+          "name": "competitions_creator_id_idx",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitions_status_idx": {
+          "name": "competitions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitions_start_date_idx": {
+          "name": "competitions_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_creator_id_users_id_fk": {
+          "name": "competitions_creator_id_users_id_fk",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competitions_target_exercise_id_exercises_id_fk": {
+          "name": "competitions_target_exercise_id_exercises_id_fk",
+          "tableFrom": "competitions",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "target_exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.exercise_aliases": {
+      "name": "exercise_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exercise_aliases_exercise_alias_idx": {
+          "name": "exercise_aliases_exercise_alias_idx",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_aliases_alias_idx": {
+          "name": "exercise_aliases_alias_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_aliases_exercise_id_exercises_id_fk": {
+          "name": "exercise_aliases_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_aliases",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_muscles": {
+          "name": "primary_muscles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_muscles": {
+          "name": "secondary_muscles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "difficulty_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_pattern": {
+          "name": "movement_pattern",
+          "type": "movement_pattern",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_type": {
+          "name": "exercise_type",
+          "type": "exercise_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_times_used": {
+          "name": "total_times_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_score": {
+          "name": "popularity_score",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exercises_name_idx": {
+          "name": "exercises_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_difficulty_idx": {
+          "name": "exercises_difficulty_idx",
+          "columns": [
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_movement_pattern_idx": {
+          "name": "exercises_movement_pattern_idx",
+          "columns": [
+            {
+              "expression": "movement_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_exercise_type_idx": {
+          "name": "exercises_exercise_type_idx",
+          "columns": [
+            {
+              "expression": "exercise_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_popularity_score_idx": {
+          "name": "exercises_popularity_score_idx",
+          "columns": [
+            {
+              "expression": "popularity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_is_custom_idx": {
+          "name": "exercises_is_custom_idx",
+          "columns": [
+            {
+              "expression": "is_custom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercises_created_by_users_id_fk": {
+          "name": "exercises_created_by_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exercises_name_unique": {
+          "name": "exercises_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.personal_records": {
+      "name": "personal_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_records_user_exercise_type_idx": {
+          "name": "personal_records_user_exercise_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_records_user_id_users_id_fk": {
+          "name": "personal_records_user_id_users_id_fk",
+          "tableFrom": "personal_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_records_exercise_id_exercises_id_fk": {
+          "name": "personal_records_exercise_id_exercises_id_fk",
+          "tableFrom": "personal_records",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_records_set_id_sets_id_fk": {
+          "name": "personal_records_set_id_sets_id_fk",
+          "tableFrom": "personal_records",
+          "tableTo": "sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.program_weeks": {
+      "name": "program_weeks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "day_number": {
+          "name": "day_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_label": {
+          "name": "day_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "program_week_day_idx": {
+          "name": "program_week_day_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "program_weeks_program_id_idx": {
+          "name": "program_weeks_program_id_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_weeks_program_id_workout_programs_id_fk": {
+          "name": "program_weeks_program_id_workout_programs_id_fk",
+          "tableFrom": "program_weeks",
+          "tableTo": "workout_programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_weeks_template_id_workout_templates_id_fk": {
+          "name": "program_weeks_template_id_workout_templates_id_fk",
+          "tableFrom": "program_weeks",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.progress_photos": {
+      "name": "progress_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_level": {
+          "name": "privacy_level",
+          "type": "privacy_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'private'"
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "progress_photos_user_id_idx": {
+          "name": "progress_photos_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "progress_photos_user_taken_at_idx": {
+          "name": "progress_photos_user_taken_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "taken_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "progress_photos_user_id_users_id_fk": {
+          "name": "progress_photos_user_id_users_id_fk",
+          "tableFrom": "progress_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sets": {
+      "name": "sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workout_exercise_id": {
+          "name": "workout_exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_lbs": {
+          "name": "weight_lbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_type": {
+          "name": "set_type",
+          "type": "set_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rpe": {
+          "name": "rpe",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_updated_at": {
+          "name": "client_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sets_workout_exercise_id_idx": {
+          "name": "sets_workout_exercise_id_idx",
+          "columns": [
+            {
+              "expression": "workout_exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sets_workout_exercise_set_idx": {
+          "name": "sets_workout_exercise_set_idx",
+          "columns": [
+            {
+              "expression": "workout_exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sets_client_id_idx": {
+          "name": "sets_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sets_workout_exercise_id_workout_exercises_id_fk": {
+          "name": "sets_workout_exercise_id_workout_exercises_id_fk",
+          "tableFrom": "sets",
+          "tableTo": "workout_exercises",
+          "columnsFrom": [
+            "workout_exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sync_conflict_log": {
+      "name": "sync_conflict_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_data": {
+          "name": "client_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_data": {
+          "name": "server_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_data": {
+          "name": "resolved_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_timestamp": {
+          "name": "client_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_timestamp": {
+          "name": "server_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "conflict_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_conflict_log_user_id_idx": {
+          "name": "sync_conflict_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_conflict_log_entity_idx": {
+          "name": "sync_conflict_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_conflict_log_user_id_users_id_fk": {
+          "name": "sync_conflict_log_user_id_users_id_fk",
+          "tableFrom": "sync_conflict_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started": {
+          "name": "last_sync_started",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed": {
+          "name": "last_sync_completed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_failed": {
+          "name": "last_sync_failed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_sync_status": {
+          "name": "current_sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'completed'"
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_syncs": {
+          "name": "total_syncs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "successful_syncs": {
+          "name": "successful_syncs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_syncs": {
+          "name": "failed_syncs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_sync_device_id": {
+          "name": "last_sync_device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_app_version": {
+          "name": "last_sync_app_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_metadata_user_id_idx": {
+          "name": "sync_metadata_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_metadata_user_id_users_id_fk": {
+          "name": "sync_metadata_user_id_users_id_fk",
+          "tableFrom": "sync_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sync_queue": {
+      "name": "sync_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "sync_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_timestamp": {
+          "name": "client_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_queue_user_id_idx": {
+          "name": "sync_queue_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_queue_status_idx": {
+          "name": "sync_queue_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_queue_entity_type_idx": {
+          "name": "sync_queue_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_queue_user_id_users_id_fk": {
+          "name": "sync_queue_user_id_users_id_fk",
+          "tableFrom": "sync_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.template_exercises": {
+      "name": "template_exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warmup_sets": {
+          "name": "warmup_sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "working_sets": {
+          "name": "working_sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_reps": {
+          "name": "target_reps",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rest_seconds": {
+          "name": "rest_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_exercises_template_id_idx": {
+          "name": "template_exercises_template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_exercises_template_order_idx": {
+          "name": "template_exercises_template_order_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_exercises_template_id_workout_templates_id_fk": {
+          "name": "template_exercises_template_id_workout_templates_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "template_exercises_exercise_id_exercises_id_fk": {
+          "name": "template_exercises_exercise_id_exercises_id_fk",
+          "tableFrom": "template_exercises",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.template_likes": {
+      "name": "template_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_likes_template_idx": {
+          "name": "template_likes_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_likes_user_id_users_id_fk": {
+          "name": "template_likes_user_id_users_id_fk",
+          "tableFrom": "template_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "template_likes_template_id_workout_templates_id_fk": {
+          "name": "template_likes_template_id_workout_templates_id_fk",
+          "tableFrom": "template_likes",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "template_likes_user_id_template_id_pk": {
+          "name": "template_likes_user_id_template_id_pk",
+          "columns": [
+            "user_id",
+            "template_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_devices": {
+      "name": "user_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_devices_user_device_idx": {
+          "name": "user_devices_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_devices_user_id_idx": {
+          "name": "user_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_devices_user_id_users_id_fk": {
+          "name": "user_devices_user_id_users_id_fk",
+          "tableFrom": "user_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_exercise_history": {
+      "name": "user_exercise_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_exercise_history_user_exercise_idx": {
+          "name": "user_exercise_history_user_exercise_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_exercise_history_user_last_used_idx": {
+          "name": "user_exercise_history_user_last_used_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_exercise_history_user_id_users_id_fk": {
+          "name": "user_exercise_history_user_id_users_id_fk",
+          "tableFrom": "user_exercise_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_exercise_history_exercise_id_exercises_id_fk": {
+          "name": "user_exercise_history_exercise_id_exercises_id_fk",
+          "tableFrom": "user_exercise_history",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_follows_follower_id_following_id_pk": {
+          "name": "user_follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_preference": {
+          "name": "unit_preference",
+          "type": "unit_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'imperial'"
+        },
+        "is_public_profile": {
+          "name": "is_public_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "total_volume_lifted_lbs": {
+          "name": "total_volume_lifted_lbs",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_workouts": {
+          "name": "total_workouts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "current_workout_streak": {
+          "name": "current_workout_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "longest_workout_streak": {
+          "name": "longest_workout_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_workout_date": {
+          "name": "last_workout_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_notification_tokens": {
+          "name": "push_notification_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_firebase_uid_idx": {
+          "name": "users_firebase_uid_idx",
+          "columns": [
+            {
+              "expression": "firebase_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_handle_idx": {
+          "name": "users_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "firebase_uid"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_handle_unique": {
+          "name": "users_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      }
+    },
+    "public.workout_exercises": {
+      "name": "workout_exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exercise_name": {
+          "name": "exercise_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_muscles": {
+          "name": "primary_muscles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_updated_at": {
+          "name": "client_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workout_exercises_workout_id_idx": {
+          "name": "workout_exercises_workout_id_idx",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workout_exercises_workout_order_idx": {
+          "name": "workout_exercises_workout_order_idx",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workout_exercises_client_id_idx": {
+          "name": "workout_exercises_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_exercises_workout_id_workouts_id_fk": {
+          "name": "workout_exercises_workout_id_workouts_id_fk",
+          "tableFrom": "workout_exercises",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workout_exercises_exercise_id_exercises_id_fk": {
+          "name": "workout_exercises_exercise_id_exercises_id_fk",
+          "tableFrom": "workout_exercises",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.workout_programs": {
+      "name": "workout_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_per_week": {
+          "name": "days_per_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "duration_weeks": {
+          "name": "duration_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_day_index": {
+          "name": "current_day_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "times_completed": {
+          "name": "times_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "privacy_level": {
+          "name": "privacy_level",
+          "type": "privacy_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'private'"
+        },
+        "is_ai_generated": {
+          "name": "is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ai_prompt": {
+          "name": "ai_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workout_programs_user_id_idx": {
+          "name": "workout_programs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workout_programs_user_active_idx": {
+          "name": "workout_programs_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_programs_user_id_users_id_fk": {
+          "name": "workout_programs_user_id_users_id_fk",
+          "tableFrom": "workout_programs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.workout_templates": {
+      "name": "workout_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "privacy_level": {
+          "name": "privacy_level",
+          "type": "privacy_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'private'"
+        },
+        "is_ai_generated": {
+          "name": "is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ai_prompt": {
+          "name": "ai_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workout_templates_user_id_idx": {
+          "name": "workout_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workout_templates_is_public_idx": {
+          "name": "workout_templates_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_templates_user_id_users_id_fk": {
+          "name": "workout_templates_user_id_users_id_fk",
+          "tableFrom": "workout_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_volume_lbs": {
+          "name": "total_volume_lbs",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sets": {
+          "name": "total_sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_reps": {
+          "name": "total_reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_updated_at": {
+          "name": "client_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workouts_user_id_idx": {
+          "name": "workouts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workouts_date_idx": {
+          "name": "workouts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workouts_user_date_idx": {
+          "name": "workouts_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workouts_client_id_idx": {
+          "name": "workouts_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workouts_user_id_users_id_fk": {
+          "name": "workouts_user_id_users_id_fk",
+          "tableFrom": "workouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workouts_template_id_workout_templates_id_fk": {
+          "name": "workouts_template_id_workout_templates_id_fk",
+          "tableFrom": "workouts",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.competition_status": {
+      "name": "competition_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "individual",
+        "group",
+        "team"
+      ]
+    },
+    "public.conflict_resolution": {
+      "name": "conflict_resolution",
+      "schema": "public",
+      "values": [
+        "client_wins",
+        "server_wins",
+        "merged"
+      ]
+    },
+    "public.difficulty_level": {
+      "name": "difficulty_level",
+      "schema": "public",
+      "values": [
+        "beginner",
+        "intermediate",
+        "advanced"
+      ]
+    },
+    "public.exercise_type": {
+      "name": "exercise_type",
+      "schema": "public",
+      "values": [
+        "compound",
+        "isolation",
+        "cardio",
+        "plyometric",
+        "stretch"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other",
+        "prefer_not_to_say"
+      ]
+    },
+    "public.movement_pattern": {
+      "name": "movement_pattern",
+      "schema": "public",
+      "values": [
+        "push",
+        "pull",
+        "hinge",
+        "squat",
+        "lunge",
+        "carry",
+        "rotation",
+        "core"
+      ]
+    },
+    "public.muscle_group": {
+      "name": "muscle_group",
+      "schema": "public",
+      "values": [
+        "chest",
+        "back",
+        "shoulders",
+        "biceps",
+        "triceps",
+        "quads",
+        "hamstrings",
+        "glutes",
+        "calves",
+        "abs",
+        "forearms",
+        "traps",
+        "lats"
+      ]
+    },
+    "public.privacy_level": {
+      "name": "privacy_level",
+      "schema": "public",
+      "values": [
+        "private",
+        "friends",
+        "public"
+      ]
+    },
+    "public.set_type": {
+      "name": "set_type",
+      "schema": "public",
+      "values": [
+        "warmup",
+        "working"
+      ]
+    },
+    "public.sync_operation": {
+      "name": "sync_operation",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "syncing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.unit_preference": {
+      "name": "unit_preference",
+      "schema": "public",
+      "values": [
+        "metric",
+        "imperial"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1768859109368,
       "tag": "0006_tidy_boomerang",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1768917636652,
+      "tag": "0007_volatile_richard_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { getOrCreateUser, updateUserProfile } from './services/userService';
 import { SyncService, SyncPayload } from './services/syncService';
 import exerciseRoutes from './routes/exercises';
 import templateRoutes from './routes/templates';
+import programRoutes from './routes/programs';
 import { validateUserProfileUpdate, validateSyncPayload } from './utils/validation';
 import {
   generateCorrelationId,
@@ -211,6 +212,9 @@ app.use('/api/exercises', exerciseRoutes);
 
 // Template API routes (rate limiting handled in routes file for write operations only)
 app.use('/api/templates', templateRoutes);
+
+// Program API routes (rate limiting handled in routes file for write operations only)
+app.use('/api/programs', programRoutes);
 
 // Sync endpoint - sync user's workout data
 app.post('/api/sync', syncLimiter, firebaseAuthMiddleware, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {

--- a/src/models/program.types.ts
+++ b/src/models/program.types.ts
@@ -1,0 +1,150 @@
+/**
+ * TypeScript types for workout programs API
+ */
+
+// ============ Query Types ============
+
+/**
+ * Query parameters for listing programs
+ */
+export interface ProgramListQuery {
+  cursor?: string;
+  limit?: number;
+  sort?: ProgramSortOption;
+  order?: 'asc' | 'desc';
+}
+
+export type ProgramSortOption = 'name' | 'createdAt' | 'updatedAt';
+
+// ============ Response Types ============
+
+/**
+ * Program data for list view (minimal fields)
+ */
+export interface ProgramListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  daysPerWeek: number;
+  durationWeeks: number | null;
+  isActive: boolean;
+  currentDayIndex: number;
+  timesCompleted: number;
+  workoutCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Full program detail with workouts
+ */
+export interface ProgramDetail {
+  id: string;
+  name: string;
+  description: string | null;
+  daysPerWeek: number;
+  durationWeeks: number | null;
+  isActive: boolean;
+  currentDayIndex: number;
+  timesCompleted: number;
+  isPublic: boolean;
+  isAiGenerated: boolean;
+  workouts: ProgramWorkoutDetail[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Workout (day) within a program
+ */
+export interface ProgramWorkoutDetail {
+  id: string;
+  dayNumber: number;
+  dayLabel: string | null;
+  templateId: string;
+  template: {
+    id: string;
+    name: string;
+    description: string | null;
+    exerciseCount: number;
+  };
+}
+
+/**
+ * Response for program list endpoint
+ */
+export interface ProgramListResponse {
+  programs: ProgramListItem[];
+  pagination: {
+    nextCursor: string | null;
+    hasMore: boolean;
+  };
+}
+
+/**
+ * Active program with next workout info
+ */
+export interface ActiveProgramResponse {
+  program: ProgramDetail;
+  nextWorkout: {
+    dayNumber: number;
+    dayLabel: string | null;
+    template: {
+      id: string;
+      name: string;
+      description: string | null;
+      exerciseCount: number;
+    };
+  } | null;
+  isCompleted: boolean; // true if timesCompleted >= durationWeeks (for finite programs)
+}
+
+// ============ Input Types ============
+
+/**
+ * Workout input when creating/updating a program
+ */
+export interface ProgramWorkoutInput {
+  dayNumber: number; // 0-based day index
+  templateId: string;
+  dayLabel?: string;
+}
+
+/**
+ * Input for creating a new program
+ */
+export interface CreateProgramInput {
+  name: string;
+  description?: string;
+  daysPerWeek: number; // 1-7
+  durationWeeks?: number; // null = indefinite
+  workouts: ProgramWorkoutInput[];
+}
+
+/**
+ * Input for updating program metadata
+ */
+export interface UpdateProgramInput {
+  name?: string;
+  description?: string;
+  daysPerWeek?: number;
+  durationWeeks?: number | null;
+}
+
+/**
+ * Input for bulk updating program workouts
+ */
+export interface UpdateProgramWorkoutsInput {
+  workouts: ProgramWorkoutInput[];
+}
+
+// ============ Cursor Types ============
+
+/**
+ * Cursor data for pagination
+ */
+export interface ProgramCursorData {
+  id: string;
+  sortValue: string | number | null;
+  sortField: ProgramSortOption;
+}

--- a/src/routes/programs.ts
+++ b/src/routes/programs.ts
@@ -1,0 +1,573 @@
+import { Router, Response, Request } from 'express';
+import rateLimit from 'express-rate-limit';
+import { AuthenticatedRequest, firebaseAuthMiddleware } from '../middleware/auth';
+import { getOrCreateUser } from '../services/userService';
+import {
+  getPrograms,
+  getProgramById,
+  getActiveProgram,
+  createProgram,
+  updateProgram,
+  deleteProgram,
+  updateProgramWorkouts,
+  activateProgram,
+  deactivateProgram,
+  advanceDay,
+  resetProgress,
+  verifyProgramOwnership,
+} from '../services/programService';
+import { ProgramListQuery } from '../models/program.types';
+import {
+  validateProgramListQuery,
+  validateCreateProgram,
+  validateUpdateProgram,
+  validateProgramWorkouts,
+  isValidUuid,
+} from '../utils/validation';
+import {
+  generateCorrelationId,
+  logError,
+  logInfo,
+  sendErrorResponse,
+} from '../utils/errorResponse';
+import { config } from '../config';
+
+const router = Router();
+const isDevelopment = config.env === 'development';
+
+// ============ Helpers ============
+
+/**
+ * Extract correlation ID from request
+ */
+function getCorrelationId(req: Request): string {
+  return (req as Request & { correlationId?: string }).correlationId || generateCorrelationId();
+}
+
+// ============ Rate Limiting ============
+
+// Rate limiter for write operations (POST, PUT, DELETE)
+const programWriteLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: isDevelopment ? 200 : 50, // 50 program write operations per hour
+  message: {
+    success: false,
+    message: 'Too many program operations, please try again later',
+    correlationId: 'rate-limit-program'
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+// ============ Middleware ============
+
+// All routes require authentication
+router.use(firebaseAuthMiddleware);
+
+// ============ Read Routes (no rate limiting) ============
+
+/**
+ * GET /api/programs
+ * List user's programs with pagination
+ */
+router.get('/', async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    // Validate query parameters
+    const validation = validateProgramListQuery(req.query as Record<string, unknown>);
+    if (!validation.valid) {
+      sendErrorResponse(res, 400, 'Invalid query parameters', undefined, correlationId, {
+        validationErrors: validation.errors
+      });
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    // Build query with defaults
+    const query: ProgramListQuery = {
+      cursor: validation.sanitized?.cursor,
+      limit: validation.sanitized?.limit,
+      sort: validation.sanitized?.sort || 'createdAt',
+      order: validation.sanitized?.order || 'desc'
+    };
+
+    const result = await getPrograms(user.id, query);
+
+    res.json({
+      success: true,
+      data: result,
+      correlationId
+    });
+  } catch (error) {
+    logError('GET /api/programs', error, correlationId);
+    sendErrorResponse(res, 500, 'Failed to fetch programs', error, correlationId);
+  }
+});
+
+/**
+ * GET /api/programs/active
+ * Get the user's active program with next workout info
+ */
+router.get('/active', async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const result = await getActiveProgram(user.id);
+
+    if (!result) {
+      res.status(404).json({
+        success: false,
+        message: 'No active program found',
+        correlationId
+      });
+      return;
+    }
+
+    res.json({
+      success: true,
+      data: result,
+      correlationId
+    });
+  } catch (error) {
+    logError('GET /api/programs/active', error, correlationId);
+    sendErrorResponse(res, 500, 'Failed to fetch active program', error, correlationId);
+  }
+});
+
+/**
+ * GET /api/programs/:id
+ * Get program with all workouts
+ */
+router.get('/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await getProgramById(id, user.id);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('GET /api/programs/:id', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to fetch program', error, correlationId);
+  }
+});
+
+// ============ Write Routes (with rate limiting) ============
+
+/**
+ * POST /api/programs
+ * Create a new program with workouts
+ */
+router.post('/', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    // Validate request body
+    const validation = validateCreateProgram(req.body);
+    if (!validation.valid) {
+      sendErrorResponse(res, 400, 'Invalid request data', undefined, correlationId, {
+        validationErrors: validation.errors
+      });
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await createProgram(user.id, validation.sanitized!);
+
+    logInfo('POST /api/programs', 'Program created', correlationId, {
+      userId: user.id,
+      programId: program.id
+    });
+
+    res.status(201).json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('POST /api/programs', error, correlationId);
+
+    // Handle specific errors
+    if (error instanceof Error && error.message.includes('Templates not found')) {
+      sendErrorResponse(res, 400, error.message, undefined, correlationId);
+      return;
+    }
+
+    sendErrorResponse(res, 500, 'Failed to create program', error, correlationId);
+  }
+});
+
+/**
+ * PUT /api/programs/:id
+ * Update program metadata (name, description, daysPerWeek, durationWeeks)
+ */
+router.put('/:id', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Validate request body
+    const validation = validateUpdateProgram(req.body);
+    if (!validation.valid) {
+      sendErrorResponse(res, 400, 'Invalid request data', undefined, correlationId, {
+        validationErrors: validation.errors
+      });
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await updateProgram(id, user.id, validation.sanitized!);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('PUT /api/programs/:id', 'Program updated', correlationId, {
+      userId: user.id,
+      programId: id
+    });
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('PUT /api/programs/:id', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to update program', error, correlationId);
+  }
+});
+
+/**
+ * DELETE /api/programs/:id
+ * Delete program (workouts cascade, templates preserved)
+ */
+router.delete('/:id', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const deleted = await deleteProgram(id, user.id);
+
+    if (!deleted) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('DELETE /api/programs/:id', 'Program deleted', correlationId, {
+      userId: user.id,
+      programId: id
+    });
+
+    res.json({
+      success: true,
+      message: 'Program deleted successfully',
+      correlationId
+    });
+  } catch (error) {
+    logError('DELETE /api/programs/:id', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to delete program', error, correlationId);
+  }
+});
+
+/**
+ * PUT /api/programs/:id/workouts
+ * Bulk update/replace program workouts
+ */
+router.put('/:id/workouts', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    // First fetch the program to get daysPerWeek for validation
+    const existingProgram = await verifyProgramOwnership(id, user.id);
+    if (!existingProgram) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    // Validate request body with the program's daysPerWeek
+    const validation = validateProgramWorkouts(req.body, existingProgram.daysPerWeek);
+    if (!validation.valid) {
+      sendErrorResponse(res, 400, 'Invalid request data', undefined, correlationId, {
+        validationErrors: validation.errors
+      });
+      return;
+    }
+
+    const program = await updateProgramWorkouts(id, user.id, validation.sanitized!.workouts);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('PUT /api/programs/:id/workouts', 'Program workouts updated', correlationId, {
+      userId: user.id,
+      programId: id,
+      workoutCount: validation.sanitized!.workouts.length
+    });
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('PUT /api/programs/:id/workouts', error, correlationId, { programId: req.params.id });
+
+    // Handle specific errors
+    if (error instanceof Error && error.message.includes('Templates not found')) {
+      sendErrorResponse(res, 400, error.message, undefined, correlationId);
+      return;
+    }
+
+    sendErrorResponse(res, 500, 'Failed to update program workouts', error, correlationId);
+  }
+});
+
+/**
+ * POST /api/programs/:id/activate
+ * Set program as active (deactivates any other active program)
+ */
+router.post('/:id/activate', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await activateProgram(id, user.id);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('POST /api/programs/:id/activate', 'Program activated', correlationId, {
+      userId: user.id,
+      programId: id
+    });
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('POST /api/programs/:id/activate', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to activate program', error, correlationId);
+  }
+});
+
+/**
+ * POST /api/programs/:id/deactivate
+ * Remove active status from program
+ */
+router.post('/:id/deactivate', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await deactivateProgram(id, user.id);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('POST /api/programs/:id/deactivate', 'Program deactivated', correlationId, {
+      userId: user.id,
+      programId: id
+    });
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('POST /api/programs/:id/deactivate', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to deactivate program', error, correlationId);
+  }
+});
+
+/**
+ * POST /api/programs/:id/advance
+ * Advance to the next day in the program rotation
+ */
+router.post('/:id/advance', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await advanceDay(id, user.id);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('POST /api/programs/:id/advance', 'Program day advanced', correlationId, {
+      userId: user.id,
+      programId: id,
+      newDayIndex: program.currentDayIndex,
+      timesCompleted: program.timesCompleted
+    });
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('POST /api/programs/:id/advance', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to advance program day', error, correlationId);
+  }
+});
+
+/**
+ * POST /api/programs/:id/reset
+ * Reset program progress to day 0
+ */
+router.post('/:id/reset', programWriteLimiter, async (req: AuthenticatedRequest, res: Response) => {
+  const correlationId = getCorrelationId(req);
+  try {
+    const { id } = req.params;
+
+    if (!isValidUuid(id)) {
+      sendErrorResponse(res, 400, 'Invalid program ID format', undefined, correlationId);
+      return;
+    }
+
+    // Get user
+    const user = await getOrCreateUser(req.user!);
+
+    const program = await resetProgress(id, user.id);
+
+    if (!program) {
+      res.status(404).json({
+        success: false,
+        message: 'Program not found',
+        correlationId
+      });
+      return;
+    }
+
+    logInfo('POST /api/programs/:id/reset', 'Program progress reset', correlationId, {
+      userId: user.id,
+      programId: id
+    });
+
+    res.json({
+      success: true,
+      data: { program },
+      correlationId
+    });
+  } catch (error) {
+    logError('POST /api/programs/:id/reset', error, correlationId, { programId: req.params.id });
+    sendErrorResponse(res, 500, 'Failed to reset program progress', error, correlationId);
+  }
+});
+
+export default router;

--- a/src/routes/programs.ts
+++ b/src/routes/programs.ts
@@ -272,6 +272,13 @@ router.put('/:id', programWriteLimiter, async (req: AuthenticatedRequest, res: R
     });
   } catch (error) {
     logError('PUT /api/programs/:id', error, correlationId, { programId: req.params.id });
+
+    // Handle daysPerWeek reduction error (would orphan workouts)
+    if (error instanceof Error && error.message.includes('Cannot reduce daysPerWeek')) {
+      sendErrorResponse(res, 400, error.message, undefined, correlationId);
+      return;
+    }
+
     sendErrorResponse(res, 500, 'Failed to update program', error, correlationId);
   }
 });

--- a/src/services/programService.test.ts
+++ b/src/services/programService.test.ts
@@ -1,0 +1,520 @@
+// Mock the database module before importing programService
+jest.mock('../db', () => ({
+  db: {}
+}));
+
+// Mock the schema module
+jest.mock('../db/schema', () => ({
+  workoutPrograms: {},
+  programWeeks: {},
+  workoutTemplates: {},
+  templateExercises: {}
+}));
+
+import { encodeCursor, decodeCursor } from './programService';
+import { ProgramCursorData } from '../models/program.types';
+import {
+  validateProgramListQuery,
+  validateCreateProgram,
+  validateUpdateProgram,
+  validateProgramWorkouts,
+  isValidUuid,
+  PROGRAM_LIMITS
+} from '../utils/validation';
+
+describe('programService', () => {
+  describe('cursor encoding/decoding', () => {
+    it('should correctly encode and decode cursor data with string sortValue (name)', () => {
+      const cursorData: ProgramCursorData = {
+        id: 'test-uuid-1234',
+        sortValue: 'PPL Program',
+        sortField: 'name'
+      };
+
+      const encoded = encodeCursor(cursorData);
+      const decoded = decodeCursor(encoded);
+
+      expect(decoded).toEqual(cursorData);
+    });
+
+    it('should correctly encode and decode cursor data with date sortValue (createdAt)', () => {
+      const cursorData: ProgramCursorData = {
+        id: 'test-uuid-5678',
+        sortValue: '2024-01-15T10:30:00.000Z',
+        sortField: 'createdAt'
+      };
+
+      const encoded = encodeCursor(cursorData);
+      const decoded = decodeCursor(encoded);
+
+      expect(decoded).toEqual(cursorData);
+    });
+
+    it('should correctly encode and decode cursor data with date sortValue (updatedAt)', () => {
+      const cursorData: ProgramCursorData = {
+        id: 'test-uuid-9999',
+        sortValue: '2024-06-20T15:45:30.000Z',
+        sortField: 'updatedAt'
+      };
+
+      const encoded = encodeCursor(cursorData);
+      const decoded = decodeCursor(encoded);
+
+      expect(decoded).toEqual(cursorData);
+    });
+
+    it('should correctly encode and decode cursor data with null sortValue', () => {
+      const cursorData: ProgramCursorData = {
+        id: 'test-uuid-null',
+        sortValue: null,
+        sortField: 'name'
+      };
+
+      const encoded = encodeCursor(cursorData);
+      const decoded = decodeCursor(encoded);
+
+      expect(decoded).toEqual(cursorData);
+    });
+
+    it('should return null for invalid cursor string', () => {
+      const decoded = decodeCursor('invalid-cursor-string');
+      expect(decoded).toBeNull();
+    });
+
+    it('should return null for malformed base64', () => {
+      const decoded = decodeCursor('!!!not-valid-base64!!!');
+      expect(decoded).toBeNull();
+    });
+
+    it('should return null for valid base64 but invalid JSON', () => {
+      const notJson = Buffer.from('this is not json').toString('base64url');
+      const decoded = decodeCursor(notJson);
+      expect(decoded).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      const decoded = decodeCursor('');
+      expect(decoded).toBeNull();
+    });
+
+    it('should return null for cursor with invalid sortField', () => {
+      const invalidCursor = Buffer.from(JSON.stringify({
+        id: 'test-id',
+        sortValue: 'test',
+        sortField: 'invalidField'
+      })).toString('base64url');
+
+      const decoded = decodeCursor(invalidCursor);
+      expect(decoded).toBeNull();
+    });
+
+    it('should return null for cursor with missing id', () => {
+      const invalidCursor = Buffer.from(JSON.stringify({
+        sortValue: 'test',
+        sortField: 'name'
+      })).toString('base64url');
+
+      const decoded = decodeCursor(invalidCursor);
+      expect(decoded).toBeNull();
+    });
+
+    it('should return null for extremely long cursor (DoS prevention)', () => {
+      const longSortValue = 'a'.repeat(600);
+      const longCursor = Buffer.from(JSON.stringify({
+        id: 'test-id',
+        sortValue: longSortValue,
+        sortField: 'name'
+      })).toString('base64url');
+
+      expect(longCursor.length).toBeGreaterThan(500);
+
+      const decoded = decodeCursor(longCursor);
+      expect(decoded).toBeNull();
+    });
+
+    it('should produce URL-safe base64 encoding', () => {
+      const cursorData: ProgramCursorData = {
+        id: 'test-uuid-special',
+        sortValue: 'Program with special chars: +/=',
+        sortField: 'name'
+      };
+
+      const encoded = encodeCursor(cursorData);
+
+      expect(encoded).not.toContain('+');
+      expect(encoded).not.toContain('/');
+
+      const decoded = decodeCursor(encoded);
+      expect(decoded).toEqual(cursorData);
+    });
+
+    it('should handle all valid sort field types', () => {
+      const sortFields = ['name', 'createdAt', 'updatedAt'] as const;
+
+      for (const sortField of sortFields) {
+        const cursorData: ProgramCursorData = {
+          id: `test-${sortField}`,
+          sortValue: 'test-value',
+          sortField
+        };
+
+        const encoded = encodeCursor(cursorData);
+        const decoded = decodeCursor(encoded);
+
+        expect(decoded).toEqual(cursorData);
+        expect(decoded?.sortField).toBe(sortField);
+      }
+    });
+  });
+
+  describe('cursor round-trip integrity', () => {
+    it('should maintain data integrity through multiple encode/decode cycles', () => {
+      const originalData: ProgramCursorData = {
+        id: 'multi-cycle-test',
+        sortValue: '6-Day PPL Split',
+        sortField: 'name'
+      };
+
+      let cursor = encodeCursor(originalData);
+
+      for (let i = 0; i < 5; i++) {
+        const decoded = decodeCursor(cursor);
+        expect(decoded).toEqual(originalData);
+        cursor = encodeCursor(decoded!);
+      }
+
+      const finalDecoded = decodeCursor(cursor);
+      expect(finalDecoded).toEqual(originalData);
+    });
+  });
+});
+
+describe('program validation', () => {
+  describe('validateProgramListQuery', () => {
+    it('should accept valid query parameters', () => {
+      const result = validateProgramListQuery({
+        limit: 20,
+        sort: 'name',
+        order: 'asc'
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.limit).toBe(20);
+      expect(result.sanitized?.sort).toBe('name');
+      expect(result.sanitized?.order).toBe('asc');
+    });
+
+    it('should reject limit below 1', () => {
+      const result = validateProgramListQuery({ limit: 0 });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('limit must be at least 1');
+    });
+
+    it('should reject limit above 100', () => {
+      const result = validateProgramListQuery({ limit: 101 });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('limit cannot exceed 100');
+    });
+
+    it('should reject invalid sort option', () => {
+      const result = validateProgramListQuery({ sort: 'invalid' });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('Invalid sort option');
+    });
+
+    it('should reject invalid order option', () => {
+      const result = validateProgramListQuery({ order: 'invalid' });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('order must be "asc" or "desc"');
+    });
+
+    it('should accept empty query (use defaults)', () => {
+      const result = validateProgramListQuery({});
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validateCreateProgram', () => {
+    const validTemplateId = '12345678-1234-1234-1234-123456789abc';
+
+    it('should accept valid program input', () => {
+      const result = validateCreateProgram({
+        name: 'Push Pull Legs',
+        description: '6-day split',
+        daysPerWeek: 6,
+        workouts: [
+          { dayNumber: 0, templateId: validTemplateId, dayLabel: 'Push' },
+          { dayNumber: 1, templateId: validTemplateId, dayLabel: 'Pull' },
+          { dayNumber: 2, templateId: validTemplateId, dayLabel: 'Legs' },
+          { dayNumber: 3, templateId: validTemplateId, dayLabel: 'Push' },
+          { dayNumber: 4, templateId: validTemplateId, dayLabel: 'Pull' },
+          { dayNumber: 5, templateId: validTemplateId, dayLabel: 'Legs' }
+        ]
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.name).toBe('Push Pull Legs');
+      expect(result.sanitized?.daysPerWeek).toBe(6);
+      expect(result.sanitized?.workouts).toHaveLength(6);
+    });
+
+    it('should accept program without durationWeeks (indefinite)', () => {
+      const result = validateCreateProgram({
+        name: 'Ongoing Program',
+        daysPerWeek: 3,
+        workouts: [
+          { dayNumber: 0, templateId: validTemplateId },
+          { dayNumber: 1, templateId: validTemplateId },
+          { dayNumber: 2, templateId: validTemplateId }
+        ]
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.durationWeeks).toBeUndefined();
+    });
+
+    it('should accept program with durationWeeks (finite)', () => {
+      const result = validateCreateProgram({
+        name: '8-Week Program',
+        daysPerWeek: 4,
+        durationWeeks: 8,
+        workouts: [
+          { dayNumber: 0, templateId: validTemplateId },
+          { dayNumber: 1, templateId: validTemplateId },
+          { dayNumber: 2, templateId: validTemplateId },
+          { dayNumber: 3, templateId: validTemplateId }
+        ]
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.durationWeeks).toBe(8);
+    });
+
+    it('should reject empty name', () => {
+      const result = validateCreateProgram({
+        name: '',
+        daysPerWeek: 3,
+        workouts: [{ dayNumber: 0, templateId: validTemplateId }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('name'))).toBe(true);
+    });
+
+    it('should reject name exceeding max length', () => {
+      const result = validateCreateProgram({
+        name: 'a'.repeat(PROGRAM_LIMITS.MAX_NAME_LENGTH + 1),
+        daysPerWeek: 3,
+        workouts: [{ dayNumber: 0, templateId: validTemplateId }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('name cannot exceed'))).toBe(true);
+    });
+
+    it('should reject missing daysPerWeek', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        workouts: [{ dayNumber: 0, templateId: validTemplateId }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('daysPerWeek is required'))).toBe(true);
+    });
+
+    it('should reject daysPerWeek below 1', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 0,
+        workouts: [{ dayNumber: 0, templateId: validTemplateId }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('daysPerWeek must be between'))).toBe(true);
+    });
+
+    it('should reject daysPerWeek above 7', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 8,
+        workouts: [{ dayNumber: 0, templateId: validTemplateId }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('daysPerWeek must be between'))).toBe(true);
+    });
+
+    it('should reject empty workouts array', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 3,
+        workouts: []
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('workouts array cannot be empty');
+    });
+
+    it('should reject invalid templateId format', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 3,
+        workouts: [{ dayNumber: 0, templateId: 'invalid-uuid' }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('valid UUID'))).toBe(true);
+    });
+
+    it('should reject dayNumber outside range', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 3,
+        workouts: [{ dayNumber: 5, templateId: validTemplateId }] // 5 >= 3
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('dayNumber must be between'))).toBe(true);
+    });
+
+    it('should reject duplicate dayNumber values', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 3,
+        workouts: [
+          { dayNumber: 0, templateId: validTemplateId },
+          { dayNumber: 0, templateId: validTemplateId }
+        ]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('duplicated'))).toBe(true);
+    });
+
+    it('should reject dayLabel exceeding max length', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 3,
+        workouts: [{
+          dayNumber: 0,
+          templateId: validTemplateId,
+          dayLabel: 'a'.repeat(PROGRAM_LIMITS.MAX_DAY_LABEL_LENGTH + 1)
+        }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('dayLabel cannot exceed'))).toBe(true);
+    });
+
+    it('should reject durationWeeks above 52', () => {
+      const result = validateCreateProgram({
+        name: 'Test',
+        daysPerWeek: 3,
+        durationWeeks: 53,
+        workouts: [{ dayNumber: 0, templateId: validTemplateId }]
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('durationWeeks must be between'))).toBe(true);
+    });
+  });
+
+  describe('validateUpdateProgram', () => {
+    it('should accept valid update with name only', () => {
+      const result = validateUpdateProgram({ name: 'New Name' });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.name).toBe('New Name');
+    });
+
+    it('should accept valid update with description only', () => {
+      const result = validateUpdateProgram({ description: 'New description' });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.description).toBe('New description');
+    });
+
+    it('should accept valid update with daysPerWeek', () => {
+      const result = validateUpdateProgram({ daysPerWeek: 5 });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.daysPerWeek).toBe(5);
+    });
+
+    it('should accept null durationWeeks to make indefinite', () => {
+      const result = validateUpdateProgram({ durationWeeks: null });
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.durationWeeks).toBeNull();
+    });
+
+    it('should reject empty update body', () => {
+      const result = validateUpdateProgram({});
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('No valid fields to update');
+    });
+
+    it('should reject unknown fields', () => {
+      const result = validateUpdateProgram({ unknownField: 'value' });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Unknown fields'))).toBe(true);
+    });
+
+    it('should reject empty name', () => {
+      const result = validateUpdateProgram({ name: '   ' });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('name cannot be empty');
+    });
+
+    it('should reject invalid daysPerWeek', () => {
+      const result = validateUpdateProgram({ daysPerWeek: 8 });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('daysPerWeek must be between'))).toBe(true);
+    });
+  });
+
+  describe('validateProgramWorkouts', () => {
+    const validTemplateId = '12345678-1234-1234-1234-123456789abc';
+    const daysPerWeek = 3;
+
+    it('should accept valid workouts array', () => {
+      const result = validateProgramWorkouts({
+        workouts: [
+          { dayNumber: 0, templateId: validTemplateId },
+          { dayNumber: 1, templateId: validTemplateId },
+          { dayNumber: 2, templateId: validTemplateId }
+        ]
+      }, daysPerWeek);
+
+      expect(result.valid).toBe(true);
+      expect(result.sanitized?.workouts).toHaveLength(3);
+    });
+
+    it('should reject empty workouts array', () => {
+      const result = validateProgramWorkouts({ workouts: [] }, daysPerWeek);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('workouts array cannot be empty');
+    });
+
+    it('should reject missing workouts key', () => {
+      const result = validateProgramWorkouts({}, daysPerWeek);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('workouts must be an array');
+    });
+
+    it('should reject dayNumber outside daysPerWeek range', () => {
+      const result = validateProgramWorkouts({
+        workouts: [{ dayNumber: 3, templateId: validTemplateId }] // 3 >= 3
+      }, daysPerWeek);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('dayNumber must be between'))).toBe(true);
+    });
+  });
+});

--- a/src/services/programService.ts
+++ b/src/services/programService.ts
@@ -1,0 +1,688 @@
+import { db } from '../db';
+import {
+  workoutPrograms,
+  programWeeks,
+  workoutTemplates,
+  templateExercises,
+} from '../db/schema';
+import {
+  eq,
+  and,
+  sql,
+  desc,
+  asc,
+  inArray,
+  SQL,
+  ne
+} from 'drizzle-orm';
+import {
+  ProgramListQuery,
+  ProgramListItem,
+  ProgramDetail,
+  ProgramWorkoutDetail,
+  ProgramListResponse,
+  ProgramCursorData,
+  ProgramSortOption,
+  CreateProgramInput,
+  UpdateProgramInput,
+  ProgramWorkoutInput,
+  ActiveProgramResponse,
+} from '../models/program.types';
+
+// ============ Constants ============
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const MAX_CURSOR_LENGTH = 500;
+
+// ============ Cursor Utilities ============
+
+export function encodeCursor(data: ProgramCursorData): string {
+  return Buffer.from(JSON.stringify(data)).toString('base64url');
+}
+
+export function decodeCursor(cursor: string): ProgramCursorData | null {
+  try {
+    if (cursor.length > MAX_CURSOR_LENGTH) {
+      return null;
+    }
+
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    const parsed = JSON.parse(decoded);
+
+    if (!isValidCursorData(parsed)) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isValidCursorData(data: unknown): data is ProgramCursorData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const cursor = data as Record<string, unknown>;
+
+  if (typeof cursor.id !== 'string' || cursor.id.length === 0) {
+    return false;
+  }
+
+  if (cursor.sortValue !== null &&
+      typeof cursor.sortValue !== 'string' &&
+      typeof cursor.sortValue !== 'number') {
+    return false;
+  }
+
+  const validSortFields: ProgramSortOption[] = ['name', 'createdAt', 'updatedAt'];
+  if (typeof cursor.sortField !== 'string' || !validSortFields.includes(cursor.sortField as ProgramSortOption)) {
+    return false;
+  }
+
+  return true;
+}
+
+// ============ Helper Functions ============
+
+/**
+ * Verifies that a program belongs to the specified user
+ */
+export async function verifyProgramOwnership(
+  programId: string,
+  userId: string
+): Promise<typeof workoutPrograms.$inferSelect | null> {
+  const result = await db
+    .select()
+    .from(workoutPrograms)
+    .where(and(
+      eq(workoutPrograms.id, programId),
+      eq(workoutPrograms.userId, userId)
+    ))
+    .limit(1);
+
+  return result.length > 0 ? result[0] : null;
+}
+
+/**
+ * Validates that all template IDs exist and belong to the user
+ */
+async function validateTemplateIds(templateIds: string[], userId: string): Promise<string[]> {
+  const uniqueIds = [...new Set(templateIds)];
+
+  const existingTemplates = await db
+    .select({ id: workoutTemplates.id })
+    .from(workoutTemplates)
+    .where(and(
+      inArray(workoutTemplates.id, uniqueIds),
+      eq(workoutTemplates.userId, userId)
+    ));
+
+  const existingIds = new Set(existingTemplates.map(t => t.id));
+  const missingIds = uniqueIds.filter(id => !existingIds.has(id));
+
+  return missingIds;
+}
+
+/**
+ * Check if a template is used in any program
+ */
+export async function isTemplateUsedInPrograms(templateId: string): Promise<boolean> {
+  const result = await db
+    .select({ id: programWeeks.id })
+    .from(programWeeks)
+    .where(eq(programWeeks.templateId, templateId))
+    .limit(1);
+
+  return result.length > 0;
+}
+
+// ============ Main Service Functions ============
+
+/**
+ * Get paginated list of programs for a user
+ */
+export async function getPrograms(
+  userId: string,
+  query: ProgramListQuery
+): Promise<ProgramListResponse> {
+  const limit = Math.min(query.limit || DEFAULT_LIMIT, MAX_LIMIT);
+  const sort = query.sort || 'createdAt';
+  const order = query.order || 'desc';
+
+  const conditions: SQL[] = [eq(workoutPrograms.userId, userId)];
+
+  if (query.cursor) {
+    const cursorData = decodeCursor(query.cursor);
+    if (cursorData && cursorData.sortField === sort) {
+      const cursorCondition = buildCursorCondition(cursorData, order);
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
+  }
+
+  const orderByColumns = getOrderByColumns(sort, order);
+
+  const results = await db
+    .select({
+      id: workoutPrograms.id,
+      name: workoutPrograms.name,
+      description: workoutPrograms.description,
+      daysPerWeek: workoutPrograms.daysPerWeek,
+      durationWeeks: workoutPrograms.durationWeeks,
+      isActive: workoutPrograms.isActive,
+      currentDayIndex: workoutPrograms.currentDayIndex,
+      timesCompleted: workoutPrograms.timesCompleted,
+      createdAt: workoutPrograms.createdAt,
+      updatedAt: workoutPrograms.updatedAt,
+      workoutCount: sql<number>`(
+        SELECT COUNT(*)::int FROM program_weeks
+        WHERE program_id = ${workoutPrograms.id}
+      )`.as('workout_count')
+    })
+    .from(workoutPrograms)
+    .where(and(...conditions))
+    .orderBy(...orderByColumns)
+    .limit(limit + 1);
+
+  const hasMore = results.length > limit;
+  const programList = hasMore ? results.slice(0, limit) : results;
+
+  let nextCursor: string | null = null;
+  if (hasMore && programList.length > 0) {
+    const lastProgram = programList[programList.length - 1];
+    const sortValue = getSortValue(lastProgram, sort);
+    nextCursor = encodeCursor({
+      id: lastProgram.id,
+      sortValue,
+      sortField: sort
+    });
+  }
+
+  const programs: ProgramListItem[] = programList.map((p) => ({
+    id: p.id,
+    name: p.name,
+    description: p.description,
+    daysPerWeek: p.daysPerWeek,
+    durationWeeks: p.durationWeeks,
+    isActive: p.isActive,
+    currentDayIndex: p.currentDayIndex,
+    timesCompleted: p.timesCompleted,
+    workoutCount: p.workoutCount,
+    createdAt: p.createdAt.toISOString(),
+    updatedAt: p.updatedAt.toISOString()
+  }));
+
+  return {
+    programs,
+    pagination: {
+      nextCursor,
+      hasMore
+    }
+  };
+}
+
+/**
+ * Get a single program with all workouts
+ */
+export async function getProgramById(
+  programId: string,
+  userId: string
+): Promise<ProgramDetail | null> {
+  const program = await verifyProgramOwnership(programId, userId);
+  if (!program) {
+    return null;
+  }
+
+  // Get program workouts with template details
+  const workoutResults = await db
+    .select({
+      id: programWeeks.id,
+      dayNumber: programWeeks.dayNumber,
+      dayLabel: programWeeks.dayLabel,
+      templateId: programWeeks.templateId,
+      template: {
+        id: workoutTemplates.id,
+        name: workoutTemplates.name,
+        description: workoutTemplates.description,
+      }
+    })
+    .from(programWeeks)
+    .innerJoin(workoutTemplates, eq(programWeeks.templateId, workoutTemplates.id))
+    .where(eq(programWeeks.programId, programId))
+    .orderBy(asc(programWeeks.dayNumber));
+
+  // Get exercise counts for each template
+  const templateIds = workoutResults.map(w => w.templateId);
+  const exerciseCounts = templateIds.length > 0
+    ? await db
+        .select({
+          templateId: templateExercises.templateId,
+          count: sql<number>`COUNT(*)::int`.as('count')
+        })
+        .from(templateExercises)
+        .where(inArray(templateExercises.templateId, templateIds))
+        .groupBy(templateExercises.templateId)
+    : [];
+
+  const exerciseCountMap = new Map(exerciseCounts.map(e => [e.templateId, e.count]));
+
+  const workouts: ProgramWorkoutDetail[] = workoutResults.map((w) => ({
+    id: w.id,
+    dayNumber: w.dayNumber,
+    dayLabel: w.dayLabel,
+    templateId: w.templateId,
+    template: {
+      id: w.template.id,
+      name: w.template.name,
+      description: w.template.description,
+      exerciseCount: exerciseCountMap.get(w.templateId) || 0
+    }
+  }));
+
+  return {
+    id: program.id,
+    name: program.name,
+    description: program.description,
+    daysPerWeek: program.daysPerWeek,
+    durationWeeks: program.durationWeeks,
+    isActive: program.isActive,
+    currentDayIndex: program.currentDayIndex,
+    timesCompleted: program.timesCompleted,
+    isPublic: program.isPublic ?? false,
+    isAiGenerated: program.isAiGenerated ?? false,
+    workouts,
+    createdAt: program.createdAt.toISOString(),
+    updatedAt: program.updatedAt.toISOString()
+  };
+}
+
+/**
+ * Get active program with next workout info
+ */
+export async function getActiveProgram(userId: string): Promise<ActiveProgramResponse | null> {
+  // Find the active program
+  const activePrograms = await db
+    .select()
+    .from(workoutPrograms)
+    .where(and(
+      eq(workoutPrograms.userId, userId),
+      eq(workoutPrograms.isActive, true)
+    ))
+    .limit(1);
+
+  if (activePrograms.length === 0) {
+    return null;
+  }
+
+  const program = activePrograms[0];
+  const programDetail = await getProgramById(program.id, userId);
+
+  if (!programDetail) {
+    return null;
+  }
+
+  // Check if program is completed (for finite programs)
+  const isCompleted = program.durationWeeks !== null &&
+                      program.timesCompleted >= program.durationWeeks;
+
+  // Find next workout based on currentDayIndex
+  const nextWorkoutData = programDetail.workouts.find(
+    w => w.dayNumber === program.currentDayIndex
+  );
+
+  const nextWorkout = nextWorkoutData ? {
+    dayNumber: nextWorkoutData.dayNumber,
+    dayLabel: nextWorkoutData.dayLabel,
+    template: nextWorkoutData.template
+  } : null;
+
+  return {
+    program: programDetail,
+    nextWorkout,
+    isCompleted
+  };
+}
+
+/**
+ * Create a new program with workouts
+ */
+export async function createProgram(
+  userId: string,
+  input: CreateProgramInput
+): Promise<ProgramDetail> {
+  // Validate template IDs exist and belong to user
+  const templateIds = input.workouts.map(w => w.templateId);
+  const missingIds = await validateTemplateIds(templateIds, userId);
+  if (missingIds.length > 0) {
+    throw new Error(`Templates not found or not owned by user: ${missingIds.join(', ')}`);
+  }
+
+  // Use transaction to insert program and workouts atomically
+  const result = await db.transaction(async (tx) => {
+    const [program] = await tx
+      .insert(workoutPrograms)
+      .values({
+        userId,
+        name: input.name,
+        description: input.description || null,
+        daysPerWeek: input.daysPerWeek,
+        durationWeeks: input.durationWeeks ?? null,
+      })
+      .returning();
+
+    // Insert program workouts
+    if (input.workouts.length > 0) {
+      await tx.insert(programWeeks).values(
+        input.workouts.map((w) => ({
+          programId: program.id,
+          weekNumber: 1, // Always 1 for single-week programs
+          dayNumber: w.dayNumber,
+          templateId: w.templateId,
+          dayLabel: w.dayLabel || null,
+        }))
+      );
+    }
+
+    return program;
+  });
+
+  const created = await getProgramById(result.id, userId);
+  if (!created) {
+    throw new Error('Failed to fetch created program');
+  }
+
+  return created;
+}
+
+/**
+ * Update program metadata
+ */
+export async function updateProgram(
+  programId: string,
+  userId: string,
+  updates: UpdateProgramInput
+): Promise<ProgramDetail | null> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return null;
+  }
+
+  const updateData: Partial<typeof workoutPrograms.$inferInsert> = {
+    updatedAt: new Date()
+  };
+
+  if (updates.name !== undefined) {
+    updateData.name = updates.name;
+  }
+  if (updates.description !== undefined) {
+    updateData.description = updates.description || null;
+  }
+  if (updates.daysPerWeek !== undefined) {
+    updateData.daysPerWeek = updates.daysPerWeek;
+  }
+  if (updates.durationWeeks !== undefined) {
+    updateData.durationWeeks = updates.durationWeeks;
+  }
+
+  await db
+    .update(workoutPrograms)
+    .set(updateData)
+    .where(eq(workoutPrograms.id, programId));
+
+  return getProgramById(programId, userId);
+}
+
+/**
+ * Delete a program (workouts cascade automatically, templates preserved)
+ */
+export async function deleteProgram(
+  programId: string,
+  userId: string
+): Promise<boolean> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return false;
+  }
+
+  await db
+    .delete(workoutPrograms)
+    .where(eq(workoutPrograms.id, programId));
+
+  return true;
+}
+
+/**
+ * Bulk replace program workouts
+ */
+export async function updateProgramWorkouts(
+  programId: string,
+  userId: string,
+  workoutsInput: ProgramWorkoutInput[]
+): Promise<ProgramDetail | null> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return null;
+  }
+
+  // Validate template IDs
+  const templateIds = workoutsInput.map(w => w.templateId);
+  const missingIds = await validateTemplateIds(templateIds, userId);
+  if (missingIds.length > 0) {
+    throw new Error(`Templates not found or not owned by user: ${missingIds.join(', ')}`);
+  }
+
+  await db.transaction(async (tx) => {
+    // Delete existing workouts
+    await tx
+      .delete(programWeeks)
+      .where(eq(programWeeks.programId, programId));
+
+    // Insert new workouts
+    if (workoutsInput.length > 0) {
+      await tx.insert(programWeeks).values(
+        workoutsInput.map((w) => ({
+          programId,
+          weekNumber: 1,
+          dayNumber: w.dayNumber,
+          templateId: w.templateId,
+          dayLabel: w.dayLabel || null,
+        }))
+      );
+    }
+
+    // Update program's updatedAt
+    await tx
+      .update(workoutPrograms)
+      .set({ updatedAt: new Date() })
+      .where(eq(workoutPrograms.id, programId));
+  });
+
+  return getProgramById(programId, userId);
+}
+
+/**
+ * Activate a program (deactivates all others for the user)
+ */
+export async function activateProgram(
+  programId: string,
+  userId: string
+): Promise<ProgramDetail | null> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return null;
+  }
+
+  await db.transaction(async (tx) => {
+    // Deactivate all other programs for this user
+    await tx
+      .update(workoutPrograms)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(and(
+        eq(workoutPrograms.userId, userId),
+        eq(workoutPrograms.isActive, true),
+        ne(workoutPrograms.id, programId)
+      ));
+
+    // Activate the requested program
+    await tx
+      .update(workoutPrograms)
+      .set({ isActive: true, updatedAt: new Date() })
+      .where(eq(workoutPrograms.id, programId));
+  });
+
+  return getProgramById(programId, userId);
+}
+
+/**
+ * Deactivate a program
+ */
+export async function deactivateProgram(
+  programId: string,
+  userId: string
+): Promise<ProgramDetail | null> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return null;
+  }
+
+  await db
+    .update(workoutPrograms)
+    .set({ isActive: false, updatedAt: new Date() })
+    .where(eq(workoutPrograms.id, programId));
+
+  return getProgramById(programId, userId);
+}
+
+/**
+ * Advance to next day in the program rotation
+ */
+export async function advanceDay(
+  programId: string,
+  userId: string
+): Promise<ProgramDetail | null> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return null;
+  }
+
+  const nextDayIndex = (existing.currentDayIndex + 1) % existing.daysPerWeek;
+  const cycleCompleted = nextDayIndex === 0;
+
+  const updateData: Partial<typeof workoutPrograms.$inferInsert> = {
+    currentDayIndex: nextDayIndex,
+    updatedAt: new Date()
+  };
+
+  if (cycleCompleted) {
+    updateData.timesCompleted = existing.timesCompleted + 1;
+  }
+
+  await db
+    .update(workoutPrograms)
+    .set(updateData)
+    .where(eq(workoutPrograms.id, programId));
+
+  return getProgramById(programId, userId);
+}
+
+/**
+ * Reset program progress to day 0
+ */
+export async function resetProgress(
+  programId: string,
+  userId: string
+): Promise<ProgramDetail | null> {
+  const existing = await verifyProgramOwnership(programId, userId);
+  if (!existing) {
+    return null;
+  }
+
+  await db
+    .update(workoutPrograms)
+    .set({
+      currentDayIndex: 0,
+      timesCompleted: 0,
+      updatedAt: new Date()
+    })
+    .where(eq(workoutPrograms.id, programId));
+
+  return getProgramById(programId, userId);
+}
+
+// ============ Sorting Helpers ============
+
+function getOrderByColumns(sort: ProgramSortOption, order: 'asc' | 'desc'): SQL[] {
+  const sortFn = order === 'asc' ? asc : desc;
+  const idSort = asc(workoutPrograms.id);
+
+  switch (sort) {
+    case 'name':
+      return [sortFn(workoutPrograms.name), idSort];
+    case 'createdAt':
+      return [sortFn(workoutPrograms.createdAt), idSort];
+    case 'updatedAt':
+      return [sortFn(workoutPrograms.updatedAt), idSort];
+    default:
+      return [desc(workoutPrograms.createdAt), idSort];
+  }
+}
+
+function buildCursorCondition(
+  cursor: ProgramCursorData,
+  order: 'asc' | 'desc'
+): SQL | null {
+  const { id, sortValue, sortField } = cursor;
+
+  switch (sortField) {
+    case 'name':
+      if (order === 'asc') {
+        return sql`(${workoutPrograms.name} > ${sortValue} OR (${workoutPrograms.name} = ${sortValue} AND ${workoutPrograms.id} > ${id}))`;
+      } else {
+        return sql`(${workoutPrograms.name} < ${sortValue} OR (${workoutPrograms.name} = ${sortValue} AND ${workoutPrograms.id} > ${id}))`;
+      }
+
+    case 'createdAt':
+      if (order === 'asc') {
+        return sql`(${workoutPrograms.createdAt} > ${sortValue}::timestamp OR (${workoutPrograms.createdAt} = ${sortValue}::timestamp AND ${workoutPrograms.id} > ${id}))`;
+      } else {
+        return sql`(${workoutPrograms.createdAt} < ${sortValue}::timestamp OR (${workoutPrograms.createdAt} = ${sortValue}::timestamp AND ${workoutPrograms.id} > ${id}))`;
+      }
+
+    case 'updatedAt':
+      if (order === 'asc') {
+        return sql`(${workoutPrograms.updatedAt} > ${sortValue}::timestamp OR (${workoutPrograms.updatedAt} = ${sortValue}::timestamp AND ${workoutPrograms.id} > ${id}))`;
+      } else {
+        return sql`(${workoutPrograms.updatedAt} < ${sortValue}::timestamp OR (${workoutPrograms.updatedAt} = ${sortValue}::timestamp AND ${workoutPrograms.id} > ${id}))`;
+      }
+
+    default:
+      return sql`${workoutPrograms.id} > ${id}`;
+  }
+}
+
+interface ProgramSortData {
+  id: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function getSortValue(
+  program: ProgramSortData,
+  sort: ProgramSortOption
+): string | number | null {
+  switch (sort) {
+    case 'name':
+      return program.name;
+    case 'createdAt':
+      return program.createdAt.toISOString();
+    case 'updatedAt':
+      return program.updatedAt.toISOString();
+    default:
+      return program.createdAt.toISOString();
+  }
+}

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -392,6 +392,7 @@ export async function updateTemplate(
 
 /**
  * Delete a template (exercises cascade automatically)
+ * Throws error if template is used in any program
  */
 export async function deleteTemplate(
   templateId: string,
@@ -401,6 +402,13 @@ export async function deleteTemplate(
   const existing = await verifyTemplateOwnership(templateId, userId);
   if (!existing) {
     return false;
+  }
+
+  // Check if template is used in any programs
+  const { isTemplateUsedInPrograms } = await import('./programService');
+  const isUsed = await isTemplateUsedInPrograms(templateId);
+  if (isUsed) {
+    throw new Error('Cannot delete template: it is used in one or more programs');
   }
 
   // Delete the template (cascade will delete exercises)


### PR DESCRIPTION
## Summary
- Adds complete REST API for managing workout programs that group templates into structured routines
- Implements progress tracking with `currentDayIndex` and `timesCompleted` fields
- Enforces single active program per user with automatic deactivation of previous program
- Adds template deletion protection to prevent orphaned program references

## Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/programs` | List user's programs with pagination |
| GET | `/api/programs/active` | Get active program with next workout info |
| GET | `/api/programs/:id` | Get program with all workouts |
| POST | `/api/programs` | Create new program with workouts |
| PUT | `/api/programs/:id` | Update program metadata |
| DELETE | `/api/programs/:id` | Delete program (cascades workouts) |
| PUT | `/api/programs/:id/workouts` | Bulk update program workouts |
| POST | `/api/programs/:id/activate` | Set as active program |
| POST | `/api/programs/:id/deactivate` | Remove active status |
| POST | `/api/programs/:id/advance` | Advance to next day in rotation |
| POST | `/api/programs/:id/reset` | Reset progress to day 0 |

## Test plan
- [x] All 136 tests passing
- [x] Code review completed with no blockers
- [ ] Manual testing of program CRUD operations
- [ ] Manual testing of activate/deactivate flow
- [ ] Manual testing of day advancement and cycle completion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces workout programs as first-class entities with server-side progress tracking and robust validation.
> 
> - New `/api/programs` routes: list (cursor pagination), get by id, get active, create, update, delete, bulk update workouts, activate/deactivate, advance day, reset progress
> - Database: add `days_per_week`, `is_active`, `current_day_index`, `times_completed` to `workout_programs`; add `day_label` and default `week_number` to `program_weeks`; new indexes on `program_weeks(program_id)` and `workout_programs(user_id,is_active)`
> - Schema: align columns/defaults, add relations for `workoutPrograms`↔`programWeeks`↔`workoutTemplates`
> - Services: implement program CRUD, activation (single active per user), progress advancement, cursor encode/decode, ownership checks, and template usage checks; block template deletion when used by programs (returns 409)
> - Validation: add comprehensive validators for program queries, create/update payloads, and workouts; limits enforced
> - Wiring/tests: register routes in `index.ts`; add unit tests for cursor and validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ae1e7833102b855b5b3e65cb7c50ddb000a051c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->