### PR TITLE
Fix iOS login 500 errors on staging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,17 +30,11 @@ const allowedOrigins = process.env.ALLOWED_ORIGINS
 
 const corsOptions: cors.CorsOptions = {
   origin: (origin, callback) => {
-    // In production, require origin header for browser requests
-    // Mobile apps (Capacitor/Ionic) send origin headers, so this is safe
+    // Allow requests without Origin header (native mobile apps, curl, server-to-server)
+    // Native iOS/Android apps using URLSession/OkHttp don't send Origin headers
+    // Security is provided by Firebase auth middleware, not Origin validation
     if (!origin) {
-      if (isDevelopment) {
-        // Allow no-origin in development only (for curl, Postman, etc.)
-        callback(null, true);
-      } else {
-        // In production, reject requests without origin (prevents direct API abuse)
-        // Note: Mobile apps DO send origin headers (capacitor://localhost, ionic://localhost)
-        callback(new Error('Origin header required'));
-      }
+      callback(null, true);
       return;
     }
     if (allowedOrigins.includes(origin)) {


### PR DESCRIPTION
Native iOS apps using URLSession/CFNetwork don't send Origin headers (unlike hybrid Capacitor/Ionic apps in webviews). The previous CORS configuration incorrectly rejected these requests in production.

Security is properly enforced by Firebase auth middleware, not Origin header validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to CORS origin handling/comments; minimal behavior impact beyond permitting no-`Origin` requests that are already authenticated via Firebase middleware.
> 
> **Overview**
> Adjusts CORS origin handling in `src/index.ts` to explicitly allow requests that omit the `Origin` header (e.g., native iOS/Android clients, curl, server-to-server), preventing production CORS rejections that could surface as 500s.
> 
> The change is primarily clarification/documentation around why `!origin` is accepted and that enforcement relies on Firebase auth middleware rather than Origin validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f7fe1b55a8fdd85641fd2707dfe4a8fa19f9cb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->