### PR TITLE
Improve exercise search with ILIKE and word_similarity

### DIFF
--- a/src/services/exerciseService.ts
+++ b/src/services/exerciseService.ts
@@ -34,7 +34,7 @@ import {
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
-const SIMILARITY_THRESHOLD = 0.3;
+const WORD_SIMILARITY_THRESHOLD = 0.3;
 
 // Difficulty order for sorting
 const DIFFICULTY_ORDER: Record<string, number> = {
@@ -118,15 +118,25 @@ export async function getExercises(
   // Add filter conditions
   addFilterConditions(conditions, query);
 
-  // Handle search
+  // Handle search: combine ILIKE for prefix/substring matching with
+  // word_similarity() for fuzzy matching of misspelled terms.
+  // similarity() compared entire strings and failed on short/partial queries
+  // like "Sm" or "Smith" against "Smith Machine". word_similarity() finds the
+  // best match between the query and any substring of the target, and ILIKE
+  // catches straightforward prefix/contains matches.
   if (query.search && query.search.trim()) {
     const searchTerm = query.search.trim();
+    const ilikePattern = `%${searchTerm}%`;
     conditions.push(sql`(
-      similarity(${exercises.name}, ${searchTerm}) > ${SIMILARITY_THRESHOLD}
+      ${exercises.name} ILIKE ${ilikePattern}
+      OR word_similarity(${searchTerm}, ${exercises.name}) > ${WORD_SIMILARITY_THRESHOLD}
       OR EXISTS (
         SELECT 1 FROM exercise_aliases ea
         WHERE ea.exercise_id = ${exercises.id}
-        AND similarity(ea.alias, ${searchTerm}) > ${SIMILARITY_THRESHOLD}
+        AND (
+          ea.alias ILIKE ${ilikePattern}
+          OR word_similarity(${searchTerm}, ea.alias) > ${WORD_SIMILARITY_THRESHOLD}
+        )
       )
     )`);
   }

--- a/src/services/exerciseService.ts
+++ b/src/services/exerciseService.ts
@@ -118,27 +118,43 @@ export async function getExercises(
   // Add filter conditions
   addFilterConditions(conditions, query);
 
-  // Handle search: combine ILIKE for prefix/substring matching with
-  // word_similarity() for fuzzy matching of misspelled terms.
-  // similarity() compared entire strings and failed on short/partial queries
-  // like "Sm" or "Smith" against "Smith Machine". word_similarity() finds the
-  // best match between the query and any substring of the target, and ILIKE
-  // catches straightforward prefix/contains matches.
+  // Handle search using word_similarity() for fuzzy matching with an ILIKE
+  // prefix fallback for short queries. word_similarity() finds the best match
+  // between the search term and any substring of the target, handling both
+  // partial ("Smith" -> "Smith Machine") and misspelled queries well.
+  // For very short terms (< 3 chars), trigram matching can't produce useful
+  // scores, so we fall back to a prefix ILIKE match instead.
   if (query.search && query.search.trim()) {
     const searchTerm = query.search.trim();
-    const ilikePattern = `%${searchTerm}%`;
-    conditions.push(sql`(
-      ${exercises.name} ILIKE ${ilikePattern}
-      OR word_similarity(${searchTerm}, ${exercises.name}) > ${WORD_SIMILARITY_THRESHOLD}
-      OR EXISTS (
-        SELECT 1 FROM exercise_aliases ea
-        WHERE ea.exercise_id = ${exercises.id}
-        AND (
-          ea.alias ILIKE ${ilikePattern}
-          OR word_similarity(${searchTerm}, ea.alias) > ${WORD_SIMILARITY_THRESHOLD}
+    const escapedTerm = searchTerm.replace(/[%_\\]/g, '\\$&');
+
+    if (searchTerm.length < 3) {
+      // Too short for trigrams — use prefix match only
+      const prefixPattern = `${escapedTerm}%`;
+      conditions.push(sql`(
+        ${exercises.name} ILIKE ${prefixPattern}
+        OR EXISTS (
+          SELECT 1 FROM exercise_aliases ea
+          WHERE ea.exercise_id = ${exercises.id}
+          AND ea.alias ILIKE ${prefixPattern}
         )
-      )
-    )`);
+      )`);
+    } else {
+      // Use word_similarity for fuzzy + prefix ILIKE as a safety net
+      const prefixPattern = `${escapedTerm}%`;
+      conditions.push(sql`(
+        ${exercises.name} ILIKE ${prefixPattern}
+        OR word_similarity(${searchTerm}, ${exercises.name}) > ${WORD_SIMILARITY_THRESHOLD}
+        OR EXISTS (
+          SELECT 1 FROM exercise_aliases ea
+          WHERE ea.exercise_id = ${exercises.id}
+          AND (
+            ea.alias ILIKE ${prefixPattern}
+            OR word_similarity(${searchTerm}, ea.alias) > ${WORD_SIMILARITY_THRESHOLD}
+          )
+        )
+      )`);
+    }
   }
 
   // Use offset-based pagination if page is provided, otherwise use cursor

--- a/src/services/exerciseService.ts
+++ b/src/services/exerciseService.ts
@@ -1,7 +1,6 @@
 import { db } from '../db';
 import {
   exercises,
-  exerciseAliases,
   userExerciseHistory,
   difficultyLevelEnum,
   movementPatternEnum,
@@ -127,10 +126,10 @@ export async function getExercises(
   if (query.search && query.search.trim()) {
     const searchTerm = query.search.trim();
     const escapedTerm = searchTerm.replace(/[%_\\]/g, '\\$&');
+    const prefixPattern = `${escapedTerm}%`;
 
     if (searchTerm.length < 3) {
       // Too short for trigrams — use prefix match only
-      const prefixPattern = `${escapedTerm}%`;
       conditions.push(sql`(
         ${exercises.name} ILIKE ${prefixPattern}
         OR EXISTS (
@@ -141,7 +140,6 @@ export async function getExercises(
       )`);
     } else {
       // Use word_similarity for fuzzy + prefix ILIKE as a safety net
-      const prefixPattern = `${escapedTerm}%`;
       conditions.push(sql`(
         ${exercises.name} ILIKE ${prefixPattern}
         OR word_similarity(${searchTerm}, ${exercises.name}) > ${WORD_SIMILARITY_THRESHOLD}


### PR DESCRIPTION
## Summary
Enhanced the exercise search functionality to provide better matching for both exact/prefix matches and fuzzy matching of misspelled or partial terms.

## Key Changes
- Replaced `similarity()` function with a two-pronged approach:
  - **ILIKE pattern matching** for straightforward prefix and substring matches
  - **word_similarity()** for fuzzy matching that handles misspelled terms and partial word matches
- Applied the same search logic to both exercise names and exercise aliases
- Renamed `SIMILARITY_THRESHOLD` constant to `WORD_SIMILARITY_THRESHOLD` for clarity
- Added detailed comments explaining the rationale for the search strategy

## Implementation Details
The previous implementation using `similarity()` had limitations with short or partial queries (e.g., "Sm" or "Smith" against "Smith Machine"). The new approach combines:
1. **ILIKE** - Catches straightforward prefix/contains matches efficiently
2. **word_similarity()** - Finds the best match between the query and any substring of the target, improving fuzzy matching for misspelled terms

This dual approach is applied consistently to both the main exercise name field and the exercise_aliases table, ensuring comprehensive search coverage.

https://claude.ai/code/session_015rxHZQmTjt6VZ8HEzvmtAL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQL search predicates and introduces `word_similarity()` usage, which can affect result quality and performance and depends on Postgres trigram support.
> 
> **Overview**
> Improves exercise search matching by replacing `similarity()` checks with a combination of **prefix `ILIKE`** and **`word_similarity()`** for fuzzy matches across both `exercises.name` and `exercise_aliases.alias`.
> 
> Adds short-query handling (terms under 3 chars use prefix-only matching), escapes `%`/`_`/`\` in user input before building the `ILIKE` pattern, and renames `SIMILARITY_THRESHOLD` to `WORD_SIMILARITY_THRESHOLD` to reflect the new scoring logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd6ae0350333c3987d055bfddd4837146a7d6943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->