### PR TITLE
Add videoUrl field to exercise and template models

### DIFF
--- a/src/models/exercise.types.ts
+++ b/src/models/exercise.types.ts
@@ -47,7 +47,6 @@ export interface ExerciseListItem {
 
 export interface ExerciseDetail extends ExerciseListItem {
   instructions: string | null;
-  videoUrl: string | null;
   totalTimesUsed: number;
   createdAt: string;
   updatedAt: string;

--- a/src/models/exercise.types.ts
+++ b/src/models/exercise.types.ts
@@ -41,6 +41,7 @@ export interface ExerciseListItem {
   movementPattern: MovementPattern | null;
   exerciseType: ExerciseType | null;
   thumbnailUrl: string | null;
+  videoUrl: string | null;
   popularityScore: number;
 }
 

--- a/src/models/template.types.ts
+++ b/src/models/template.types.ts
@@ -63,6 +63,7 @@ export interface TemplateExerciseDetail {
     primaryMuscles: string[];
     equipment: string | null;
     thumbnailUrl: string | null;
+    videoUrl: string | null;
   };
 }
 

--- a/src/services/exerciseService.ts
+++ b/src/services/exerciseService.ts
@@ -191,6 +191,7 @@ export async function getExercises(
       movementPattern: exercises.movementPattern,
       exerciseType: exercises.exerciseType,
       thumbnailUrl: exercises.thumbnailUrl,
+      videoUrl: exercises.videoUrl,
       popularityScore: exercises.popularityScore
     })
     .from(exercises)
@@ -253,6 +254,7 @@ export async function getExercises(
     movementPattern: e.movementPattern,
     exerciseType: e.exerciseType,
     thumbnailUrl: e.thumbnailUrl,
+    videoUrl: e.videoUrl,
     popularityScore: parseFloat(e.popularityScore?.toString() || '0')
   }));
 

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -261,7 +261,8 @@ export async function getTemplateById(
         name: exercises.name,
         primaryMuscles: exercises.primaryMuscles,
         equipment: exercises.equipment,
-        thumbnailUrl: exercises.thumbnailUrl
+        thumbnailUrl: exercises.thumbnailUrl,
+        videoUrl: exercises.videoUrl
       }
     })
     .from(templateExercises)
@@ -284,7 +285,8 @@ export async function getTemplateById(
       name: te.exercise.name,
       primaryMuscles: (te.exercise.primaryMuscles as string[]) || [],
       equipment: te.exercise.equipment,
-      thumbnailUrl: te.exercise.thumbnailUrl
+      thumbnailUrl: te.exercise.thumbnailUrl,
+      videoUrl: te.exercise.videoUrl
     }
   }));
 


### PR DESCRIPTION
## Summary
This PR adds support for exercise video URLs across the application by introducing a new `videoUrl` field to exercise and template-related models and services.

## Changes
- **Type Definitions**: Added `videoUrl: string | null` field to:
  - `ExerciseListItem` interface in `exercise.types.ts`
  - `TemplateExerciseDetail` exercise object in `template.types.ts`

- **Exercise Service**: Updated `getExercises()` function to:
  - Include `videoUrl` in the database query selection
  - Map `videoUrl` from exercise records in the response transformation

- **Template Service**: Updated `getTemplateById()` function to:
  - Include `videoUrl` in the exercise details query selection
  - Map `videoUrl` from exercise data in the response transformation

## Implementation Details
- The `videoUrl` field is nullable (`string | null`) to maintain backward compatibility with existing exercises that may not have video content
- Changes are consistent across both database queries and response mapping in both services
- No breaking changes to existing APIs; the field is additive only

https://claude.ai/code/session_01C7BRKwjAD6xVDgfMkSckMc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, nullable field plumbed through list/detail responses; low risk aside from clients needing to tolerate an extra response property and ensuring DB column exists.
> 
> **Overview**
> Adds support for returning an exercise `videoUrl` across APIs by extending `ExerciseListItem` (and therefore `ExerciseDetail`) plus the nested `exercise` object inside `TemplateExerciseDetail` with a nullable `videoUrl`.
> 
> Updates `exerciseService.getExercises()` and `templateService.getTemplateById()` to select `exercises.videoUrl` from the database and include it in the response mapping, so clients receive the video link alongside existing media fields like `thumbnailUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4cd7cc434f9f714b41e1018004f63aa08bb6501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->